### PR TITLE
Fix Custom Permission Handling

### DIFF
--- a/src/main/java/net/aerh/slashcommands/SlashCommandManager.java
+++ b/src/main/java/net/aerh/slashcommands/SlashCommandManager.java
@@ -166,7 +166,9 @@ public class SlashCommandManager extends ListenerAdapter {
     public void onReady(@NotNull ReadyEvent event) {
         if (jda == null) {
             jda = event.getJDA();
-            jda.addEventListener(this);
+            if (!jda.getEventManager().getRegisteredListeners().contains(this)) {
+                jda.addEventListener(this);
+            }
         }
 
         registerCommandsWithJDA();

--- a/src/main/java/net/aerh/slashcommands/internal/core/PermissionManager.java
+++ b/src/main/java/net/aerh/slashcommands/internal/core/PermissionManager.java
@@ -52,27 +52,33 @@ public class PermissionManager {
      * @return the permission check result
      */
     public PermissionChecker.PermissionResult checkPermissions(SlashCommandInteractionEvent event, String[] requiredPermissions) {
-        PermissionChecker.PermissionResult result = PermissionChecker.checkPermissions(event, requiredPermissions);
+        if (requiredPermissions == null) {
+            return PermissionChecker.PermissionResult.allowed();
+        }
 
-        if (!result.wasSuccessful()) {
-            for (String permission : requiredPermissions) {
-                for (PermissionHandler handler : handlers) {
-                    if (handler.canHandle(permission)) {
-                        PermissionChecker.PermissionResult customResult = handler.checkPermission(event, permission);
-
-                        if (!customResult.wasSuccessful()) {
-                            return customResult;
-                        }
-                    }
-                }
-
-                if (permission.equals(result.getFailedPermission())) {
-                    return result;
-                }
+        for (String permission : requiredPermissions) {
+            PermissionChecker.PermissionResult result = resolvePermission(event, permission);
+            if (!result.wasSuccessful()) {
+                return result;
             }
         }
 
-        return result;
+        return PermissionChecker.PermissionResult.allowed();
+    }
+
+    /**
+     * Prioritizes custom permission handlers over built-in Discord permission checking.
+     * 
+     * @param event the slash command interaction event
+     * @param permission the permission string to resolve
+     * @return the permission check result from the first capable handler, or built-in check if none found
+     */
+    private PermissionChecker.PermissionResult resolvePermission(SlashCommandInteractionEvent event, String permission) {
+        return handlers.stream()
+                .filter(handler -> handler.canHandle(permission))
+                .findFirst()
+                .map(handler -> handler.checkPermission(event, permission))
+                .orElseGet(() -> PermissionChecker.checkPermissions(event, new String[]{permission}));
     }
 
     /**

--- a/src/main/java/net/aerh/slashcommands/internal/core/PermissionManager.java
+++ b/src/main/java/net/aerh/slashcommands/internal/core/PermissionManager.java
@@ -67,7 +67,7 @@ public class PermissionManager {
     }
 
     /**
-     * Prioritizes custom permission handlers over built-in Discord permission checking.
+     * Prioritises custom permission handlers over built-in Discord permission checking.
      * 
      * @param event the slash command interaction event
      * @param permission the permission string to resolve

--- a/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
@@ -114,6 +114,7 @@ public class SlashCommandHandler implements InteractionHandler {
             // Custom error handler for slash commands
             if (!event.isAcknowledged()) {
                 event.reply("An error occurred while executing the command.").setEphemeral(true).queue();
+                logger.error("Error executing command '{}': {}", cmd.getCommandName(), error.getMessage(), error);
             }
         });
 


### PR DESCRIPTION
This PR fixes two issues:
- An `IllegalStateException` firing since we were not checking if the event listener was already registered, thus registering twice
- Custom permission handlers not being respected for some reason when executing a command with a custom permission