### PR TITLE
fix: edit the deferred reply when a command errors after acknowledgement

### DIFF
--- a/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
@@ -8,6 +8,7 @@ import net.aerh.slashcommands.internal.execution.CommandExecutor;
 import net.aerh.slashcommands.internal.execution.ExecutableSlashCommand;
 import net.aerh.slashcommands.internal.execution.resolvers.SlashCommandArgumentResolver;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SlashCommandHandler implements InteractionHandler {
     private static final Logger logger = LoggerFactory.getLogger(SlashCommandHandler.class);
+    private static final String GENERIC_ERROR_MESSAGE = "An error occurred while executing the command.";
 
     private final SlashCommandRegistry registry;
     private final PermissionManager permissionManager;
@@ -110,13 +112,7 @@ public class SlashCommandHandler implements InteractionHandler {
         Object[] args = argumentResolver.prepareArguments(commandInfo, event);
         ExecutableSlashCommand command = new ExecutableSlashCommand(commandInfo, event, args);
 
-        boolean success = commandExecutor.execute(command, (cmd, error) -> {
-            // Custom error handler for slash commands
-            if (!event.isAcknowledged()) {
-                event.reply("An error occurred while executing the command.").setEphemeral(true).queue();
-                logger.error("Error executing command '{}': {}", cmd.getCommandName(), error.getMessage(), error);
-            }
-        });
+        boolean success = commandExecutor.execute(command, (cmd, error) -> respondWithGenericError(event));
 
         if (!success) {
             // Additional error handling if needed
@@ -135,9 +131,23 @@ public class SlashCommandHandler implements InteractionHandler {
     private void handleCommandError(SlashCommandInteractionEvent event, String commandName, String subcommandName, Exception e) {
         String fullCommandName = subcommandName != null ? commandName + " " + subcommandName : commandName;
         logger.error("Error executing command '{}': {}", fullCommandName, e.getMessage(), e);
+        respondWithGenericError(event);
+    }
 
-        if (!event.isAcknowledged()) {
-            event.reply("An error occurred while executing the command.").setEphemeral(true).queue();
+    /**
+     * Sends a generic error message to the user for a failed interaction.
+     * <p>
+     * If the interaction was already acknowledged (for example via {@code deferReply}), the original
+     * response is edited so the user is not left on a permanent "thinking" state. Otherwise an
+     * ephemeral reply is sent.
+     *
+     * @param event the interaction to respond to
+     */
+    static void respondWithGenericError(IReplyCallback event) {
+        if (event.isAcknowledged()) {
+            event.getHook().editOriginal(GENERIC_ERROR_MESSAGE).queue();
+        } else {
+            event.reply(GENERIC_ERROR_MESSAGE).setEphemeral(true).queue();
         }
     }
 

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/SlashCommandErrorResponseTest.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/SlashCommandErrorResponseTest.java
@@ -1,0 +1,111 @@
+package net.aerh.slashcommands.internal.handlers;
+
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SlashCommandErrorResponseTest {
+
+    @Test
+    @DisplayName("Should edit the original reply when the interaction is already acknowledged (e.g. deferred)")
+    void editsOriginalReplyWhenAlreadyAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(true);
+
+        SlashCommandHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("editOriginal(An error occurred while executing the command.)", "queue"),
+                interaction.calls());
+    }
+
+    @Test
+    @DisplayName("Should send an ephemeral reply when the interaction is not yet acknowledged")
+    void sendsEphemeralReplyWhenNotAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(false);
+
+        SlashCommandHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("reply(An error occurred while executing the command.)", "setEphemeral(true)", "queue"),
+                interaction.calls());
+    }
+
+    /**
+     * Proxy-based fake for a reply callback that records every interaction with the reply and hook APIs.
+     * Any method the production code is not expected to touch fails the test with
+     * {@link UnsupportedOperationException}.
+     */
+    private static final class RecordingInteraction {
+        private final List<String> calls = new ArrayList<>();
+        private final boolean acknowledged;
+
+        private RecordingInteraction(boolean acknowledged) {
+            this.acknowledged = acknowledged;
+        }
+
+        private List<String> calls() {
+            return calls;
+        }
+
+        private IReplyCallback replyCallback() {
+            return proxy(IReplyCallback.class, (proxyInstance, method, args) -> switch (method.getName()) {
+                case "isAcknowledged" -> acknowledged;
+                case "getHook" -> hook();
+                case "reply" -> {
+                    calls.add("reply(" + args[0] + ")");
+                    yield chainRecordingAction(ReplyCallbackAction.class);
+                }
+                case "toString" -> "RecordingReplyCallback";
+                default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+            });
+        }
+
+        private InteractionHook hook() {
+            return proxy(InteractionHook.class, (proxyInstance, method, args) -> switch (method.getName()) {
+                case "editOriginal" -> {
+                    calls.add("editOriginal(" + args[0] + ")");
+                    yield chainRecordingAction(WebhookMessageEditAction.class);
+                }
+                case "toString" -> "RecordingInteractionHook";
+                default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+            });
+        }
+
+        /**
+         * Creates a rest action proxy that records {@code queue()} calls and records-then-chains any other
+         * builder-style call (such as {@code setEphemeral}) by returning itself.
+         */
+        private <T> T chainRecordingAction(Class<T> type) {
+            Object[] self = new Object[1];
+            InvocationHandler handler = (proxyInstance, method, args) -> switch (method.getName()) {
+                case "queue" -> {
+                    calls.add("queue");
+                    yield null;
+                }
+                case "toString" -> "Recording" + type.getSimpleName();
+                case "hashCode" -> System.identityHashCode(proxyInstance);
+                case "equals" -> proxyInstance == args[0];
+                default -> {
+                    calls.add(method.getName() + (args != null && args.length > 0 ? "(" + args[0] + ")" : ""));
+                    yield self[0];
+                }
+            };
+            self[0] = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+            return type.cast(self[0]);
+        }
+
+        private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+            return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The slash command error handlers only replied when the interaction was **not** yet acknowledged. A command that calls `deferReply(...)` and then throws left the user on a permanent "thinking..." state with no feedback, since nothing ever edited the deferred reply — the error only appeared in server logs.

## Changes

- New `SlashCommandHandler.respondWithGenericError(IReplyCallback)`: when the interaction is already acknowledged, it edits the original response through the interaction hook (ending the thinking state); otherwise it sends an ephemeral reply as before.
- Both error paths (`executeCommand`'s error handler and `handleCommandError`) now go through it, removing a duplicated message literal and a log line that duplicated `CommandExecutor`'s own error logging.

## Testing

Two new JUnit tests assert the exact interaction sequence for both branches (acknowledged → `editOriginal` + `queue`; unacknowledged → `reply` + `setEphemeral(true)` + `queue`), using JDK dynamic-proxy recording fakes over the JDA interaction interfaces — no mocking dependency added. Full suite passes (44 tests).

Note: `ModalInteractionHandler` and `ComponentInteractionHandler` have the same swallowed-error pattern; left for a follow-up since components acknowledged via `deferEdit` need different handling (editing the original would clobber the message the component is attached to).