### PR TITLE
fix: respond to deferred interactions when a handler errors

### DIFF
--- a/src/main/java/net/aerh/slashcommands/internal/handlers/ComponentInteractionHandler.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/ComponentInteractionHandler.java
@@ -3,7 +3,9 @@ package net.aerh.slashcommands.internal.handlers;
 import net.aerh.slashcommands.internal.core.SlashCommandRegistry;
 import net.aerh.slashcommands.internal.execution.resolvers.ComponentArgumentResolver;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +15,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ComponentInteractionHandler implements InteractionHandler {
     private static final Logger logger = LoggerFactory.getLogger(ComponentInteractionHandler.class);
+    private static final String GENERIC_ERROR_MESSAGE = "An error occurred while handling the interaction.";
 
     private final SlashCommandRegistry registry;
     private final ComponentArgumentResolver argumentResolver;
@@ -68,19 +71,28 @@ public class ComponentInteractionHandler implements InteractionHandler {
         componentInfo.method().invoke(componentInfo.instance(), args);
     }
 
-    private void handleComponentError(Object event, String componentId, Exception e) {
+    private void handleComponentError(GenericComponentInteractionCreateEvent event, String componentId, Exception e) {
         logger.error("Error handling component interaction '{}': {}", componentId, e.getMessage(), e);
 
-        // Check if the event has an acknowledge method and hasn't been acknowledged
         try {
-            if (event instanceof ButtonInteractionEvent buttonEvent && !buttonEvent.isAcknowledged()) {
-                buttonEvent.reply("An error occurred while handling the interaction.").setEphemeral(true).queue();
-            } else if (event instanceof StringSelectInteractionEvent selectEvent && !selectEvent.isAcknowledged()) {
-                selectEvent.reply("An error occurred while handling the interaction.").setEphemeral(true).queue();
-            }
+            respondWithGenericError(event);
         } catch (Exception replyException) {
             logger.error("Failed to send error reply for component '{}': {}", componentId, replyException.getMessage());
         }
+    }
+
+    /**
+     * Sends a generic error message to the user for a failed component interaction.
+     * <p>
+     * Component interactions are typically acknowledged via {@code deferEdit}, where editing the
+     * original response would overwrite the message the component is attached to. If the
+     * interaction was already acknowledged, an ephemeral followup message is sent instead of
+     * editing; otherwise an ephemeral reply is sent.
+     *
+     * @param event the interaction to respond to
+     */
+    static void respondWithGenericError(IReplyCallback event) {
+        InteractionErrorResponder.replyOrFollowUp(event, GENERIC_ERROR_MESSAGE);
     }
 
     @Override

--- a/src/main/java/net/aerh/slashcommands/internal/handlers/InteractionErrorResponder.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/InteractionErrorResponder.java
@@ -1,0 +1,34 @@
+package net.aerh.slashcommands.internal.handlers;
+
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+
+/**
+ * Shared error responses for interactions whose handler threw an exception.
+ * <p>
+ * Every strategy guarantees the user gets feedback even when the interaction was already
+ * acknowledged (for example via {@code deferReply} or {@code deferEdit}), so the user is never
+ * left on a permanent "thinking" state.
+ */
+final class InteractionErrorResponder {
+
+    private InteractionErrorResponder() {
+    }
+
+    /**
+     * Replies ephemerally, or edits the original response when the interaction was already
+     * acknowledged.
+     * <p>
+     * Suitable for interactions where the acknowledged response is a reply owned by the bot
+     * (slash commands, modal submissions), so overwriting it with the error message is safe.
+     *
+     * @param event   the interaction to respond to
+     * @param message the error message to show the user
+     */
+    static void replyOrEditOriginal(IReplyCallback event, String message) {
+        if (event.isAcknowledged()) {
+            event.getHook().editOriginal(message).queue();
+        } else {
+            event.reply(message).setEphemeral(true).queue();
+        }
+    }
+}

--- a/src/main/java/net/aerh/slashcommands/internal/handlers/InteractionErrorResponder.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/InteractionErrorResponder.java
@@ -31,4 +31,23 @@ final class InteractionErrorResponder {
             event.reply(message).setEphemeral(true).queue();
         }
     }
+
+    /**
+     * Replies ephemerally, or sends an ephemeral followup message when the interaction was
+     * already acknowledged.
+     * <p>
+     * Suitable for interactions that are usually acknowledged via {@code deferEdit} (buttons,
+     * select menus), where editing the original response would overwrite the message the
+     * component is attached to.
+     *
+     * @param event   the interaction to respond to
+     * @param message the error message to show the user
+     */
+    static void replyOrFollowUp(IReplyCallback event, String message) {
+        if (event.isAcknowledged()) {
+            event.getHook().sendMessage(message).setEphemeral(true).queue();
+        } else {
+            event.reply(message).setEphemeral(true).queue();
+        }
+    }
 }

--- a/src/main/java/net/aerh/slashcommands/internal/handlers/ModalInteractionHandler.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/ModalInteractionHandler.java
@@ -3,6 +3,7 @@ package net.aerh.slashcommands.internal.handlers;
 import net.aerh.slashcommands.internal.core.SlashCommandRegistry;
 import net.aerh.slashcommands.internal.execution.resolvers.ModalArgumentResolver;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,6 +13,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ModalInteractionHandler implements InteractionHandler {
     private static final Logger logger = LoggerFactory.getLogger(ModalInteractionHandler.class);
+    private static final String GENERIC_ERROR_MESSAGE = "An error occurred while handling the modal submission.";
 
     private final SlashCommandRegistry registry;
     private final ModalArgumentResolver argumentResolver;
@@ -48,10 +50,20 @@ public class ModalInteractionHandler implements InteractionHandler {
 
     private void handleModalError(ModalInteractionEvent event, String modalId, Exception e) {
         logger.error("Error handling modal interaction '{}': {}", modalId, e.getMessage(), e);
+        respondWithGenericError(event);
+    }
 
-        if (!event.isAcknowledged()) {
-            event.reply("An error occurred while handling the modal submission.").setEphemeral(true).queue();
-        }
+    /**
+     * Sends a generic error message to the user for a failed modal submission.
+     * <p>
+     * If the interaction was already acknowledged (for example via {@code deferReply}), the original
+     * response is edited so the user is not left on a permanent "thinking" state. Otherwise an
+     * ephemeral reply is sent.
+     *
+     * @param event the interaction to respond to
+     */
+    static void respondWithGenericError(IReplyCallback event) {
+        InteractionErrorResponder.replyOrEditOriginal(event, GENERIC_ERROR_MESSAGE);
     }
 
     @Override

--- a/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
+++ b/src/main/java/net/aerh/slashcommands/internal/handlers/SlashCommandHandler.java
@@ -144,11 +144,7 @@ public class SlashCommandHandler implements InteractionHandler {
      * @param event the interaction to respond to
      */
     static void respondWithGenericError(IReplyCallback event) {
-        if (event.isAcknowledged()) {
-            event.getHook().editOriginal(GENERIC_ERROR_MESSAGE).queue();
-        } else {
-            event.reply(GENERIC_ERROR_MESSAGE).setEphemeral(true).queue();
-        }
+        InteractionErrorResponder.replyOrEditOriginal(event, GENERIC_ERROR_MESSAGE);
     }
 
     @Override

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/ComponentErrorResponseTest.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/ComponentErrorResponseTest.java
@@ -1,0 +1,35 @@
+package net.aerh.slashcommands.internal.handlers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ComponentErrorResponseTest {
+
+    @Test
+    @DisplayName("Should send an ephemeral followup when the component interaction is already acknowledged (e.g. deferred edit)")
+    void sendsEphemeralFollowupWhenAlreadyAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(true);
+
+        ComponentInteractionHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("sendMessage(An error occurred while handling the interaction.)", "setEphemeral(true)", "queue"),
+                interaction.calls());
+    }
+
+    @Test
+    @DisplayName("Should send an ephemeral reply when the component interaction is not yet acknowledged")
+    void sendsEphemeralReplyWhenNotAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(false);
+
+        ComponentInteractionHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("reply(An error occurred while handling the interaction.)", "setEphemeral(true)", "queue"),
+                interaction.calls());
+    }
+}

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/ModalErrorResponseTest.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/ModalErrorResponseTest.java
@@ -1,0 +1,35 @@
+package net.aerh.slashcommands.internal.handlers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModalErrorResponseTest {
+
+    @Test
+    @DisplayName("Should edit the original reply when the modal interaction is already acknowledged (e.g. deferred)")
+    void editsOriginalReplyWhenAlreadyAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(true);
+
+        ModalInteractionHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("editOriginal(An error occurred while handling the modal submission.)", "queue"),
+                interaction.calls());
+    }
+
+    @Test
+    @DisplayName("Should send an ephemeral reply when the modal interaction is not yet acknowledged")
+    void sendsEphemeralReplyWhenNotAcknowledged() {
+        RecordingInteraction interaction = new RecordingInteraction(false);
+
+        ModalInteractionHandler.respondWithGenericError(interaction.replyCallback());
+
+        assertEquals(
+                List.of("reply(An error occurred while handling the modal submission.)", "setEphemeral(true)", "queue"),
+                interaction.calls());
+    }
+}

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/RecordingInteraction.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/RecordingInteraction.java
@@ -1,0 +1,80 @@
+package net.aerh.slashcommands.internal.handlers;
+
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Proxy-based fake for a reply callback that records every interaction with the reply and hook APIs.
+ * Any method the production code is not expected to touch fails the test with
+ * {@link UnsupportedOperationException}.
+ */
+final class RecordingInteraction {
+    private final List<String> calls = new ArrayList<>();
+    private final boolean acknowledged;
+
+    RecordingInteraction(boolean acknowledged) {
+        this.acknowledged = acknowledged;
+    }
+
+    List<String> calls() {
+        return calls;
+    }
+
+    IReplyCallback replyCallback() {
+        return proxy(IReplyCallback.class, (proxyInstance, method, args) -> switch (method.getName()) {
+            case "isAcknowledged" -> acknowledged;
+            case "getHook" -> hook();
+            case "reply" -> {
+                calls.add("reply(" + args[0] + ")");
+                yield chainRecordingAction(ReplyCallbackAction.class);
+            }
+            case "toString" -> "RecordingReplyCallback";
+            default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+        });
+    }
+
+    private InteractionHook hook() {
+        return proxy(InteractionHook.class, (proxyInstance, method, args) -> switch (method.getName()) {
+            case "editOriginal" -> {
+                calls.add("editOriginal(" + args[0] + ")");
+                yield chainRecordingAction(WebhookMessageEditAction.class);
+            }
+            case "toString" -> "RecordingInteractionHook";
+            default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+        });
+    }
+
+    /**
+     * Creates a rest action proxy that records {@code queue()} calls and records-then-chains any other
+     * builder-style call (such as {@code setEphemeral}) by returning itself.
+     */
+    private <T> T chainRecordingAction(Class<T> type) {
+        Object[] self = new Object[1];
+        InvocationHandler handler = (proxyInstance, method, args) -> switch (method.getName()) {
+            case "queue" -> {
+                calls.add("queue");
+                yield null;
+            }
+            case "toString" -> "Recording" + type.getSimpleName();
+            case "hashCode" -> System.identityHashCode(proxyInstance);
+            case "equals" -> proxyInstance == args[0];
+            default -> {
+                calls.add(method.getName() + (args != null && args.length > 0 ? "(" + args[0] + ")" : ""));
+                yield self[0];
+            }
+        };
+        self[0] = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+        return type.cast(self[0]);
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
+    }
+}

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/RecordingInteraction.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/RecordingInteraction.java
@@ -2,6 +2,7 @@ package net.aerh.slashcommands.internal.handlers;
 
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 
@@ -45,6 +46,10 @@ final class RecordingInteraction {
             case "editOriginal" -> {
                 calls.add("editOriginal(" + args[0] + ")");
                 yield chainRecordingAction(WebhookMessageEditAction.class);
+            }
+            case "sendMessage" -> {
+                calls.add("sendMessage(" + args[0] + ")");
+                yield chainRecordingAction(WebhookMessageCreateAction.class);
             }
             case "toString" -> "RecordingInteractionHook";
             default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());

--- a/src/test/java/net/aerh/slashcommands/internal/handlers/SlashCommandErrorResponseTest.java
+++ b/src/test/java/net/aerh/slashcommands/internal/handlers/SlashCommandErrorResponseTest.java
@@ -1,15 +1,8 @@
 package net.aerh.slashcommands.internal.handlers;
 
-import net.dv8tion.jda.api.interactions.InteractionHook;
-import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction;
-import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,74 +31,5 @@ class SlashCommandErrorResponseTest {
         assertEquals(
                 List.of("reply(An error occurred while executing the command.)", "setEphemeral(true)", "queue"),
                 interaction.calls());
-    }
-
-    /**
-     * Proxy-based fake for a reply callback that records every interaction with the reply and hook APIs.
-     * Any method the production code is not expected to touch fails the test with
-     * {@link UnsupportedOperationException}.
-     */
-    private static final class RecordingInteraction {
-        private final List<String> calls = new ArrayList<>();
-        private final boolean acknowledged;
-
-        private RecordingInteraction(boolean acknowledged) {
-            this.acknowledged = acknowledged;
-        }
-
-        private List<String> calls() {
-            return calls;
-        }
-
-        private IReplyCallback replyCallback() {
-            return proxy(IReplyCallback.class, (proxyInstance, method, args) -> switch (method.getName()) {
-                case "isAcknowledged" -> acknowledged;
-                case "getHook" -> hook();
-                case "reply" -> {
-                    calls.add("reply(" + args[0] + ")");
-                    yield chainRecordingAction(ReplyCallbackAction.class);
-                }
-                case "toString" -> "RecordingReplyCallback";
-                default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
-            });
-        }
-
-        private InteractionHook hook() {
-            return proxy(InteractionHook.class, (proxyInstance, method, args) -> switch (method.getName()) {
-                case "editOriginal" -> {
-                    calls.add("editOriginal(" + args[0] + ")");
-                    yield chainRecordingAction(WebhookMessageEditAction.class);
-                }
-                case "toString" -> "RecordingInteractionHook";
-                default -> throw new UnsupportedOperationException("Unexpected call: " + method.getName());
-            });
-        }
-
-        /**
-         * Creates a rest action proxy that records {@code queue()} calls and records-then-chains any other
-         * builder-style call (such as {@code setEphemeral}) by returning itself.
-         */
-        private <T> T chainRecordingAction(Class<T> type) {
-            Object[] self = new Object[1];
-            InvocationHandler handler = (proxyInstance, method, args) -> switch (method.getName()) {
-                case "queue" -> {
-                    calls.add("queue");
-                    yield null;
-                }
-                case "toString" -> "Recording" + type.getSimpleName();
-                case "hashCode" -> System.identityHashCode(proxyInstance);
-                case "equals" -> proxyInstance == args[0];
-                default -> {
-                    calls.add(method.getName() + (args != null && args.length > 0 ? "(" + args[0] + ")" : ""));
-                    yield self[0];
-                }
-            };
-            self[0] = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
-            return type.cast(self[0]);
-        }
-
-        private static <T> T proxy(Class<T> type, InvocationHandler handler) {
-            return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
-        }
     }
 }


### PR DESCRIPTION
## Summary

Modal and component interaction error handlers only replied when the interaction was not yet acknowledged. Any handler that deferred and then threw left the user on a permanent "thinking" state (or, for components, silently swallowed the error). This PR extends the slash-command fix from #34 so every handler type gives the user feedback regardless of acknowledgement state:

| Interaction | Not acknowledged | Already acknowledged |
| --- | --- | --- |
| Slash command | ephemeral reply | edit original response |
| Modal submission | ephemeral reply | edit original response |
| Button / select menu | ephemeral reply | **ephemeral followup** |

Components get a followup instead of an edit because they are typically acknowledged via `deferEdit()`, where `editOriginal` would overwrite the message the component is attached to.

## Changes

- New package-private `InteractionErrorResponder` with the two response strategies (`replyOrEditOriginal`, `replyOrFollowUp`); all three handlers delegate to it with their own message.
- `ModalInteractionHandler` and `ComponentInteractionHandler` error paths now use the responder instead of the `!isAcknowledged()`-guarded reply.
- The component error path's `Object` parameter and per-event `instanceof` chain are replaced with the shared `GenericComponentInteractionCreateEvent` supertype.
- Recording-proxy test fake extracted from `SlashCommandErrorResponseTest` into a shared `RecordingInteraction` fixture; new `ModalErrorResponseTest` and `ComponentErrorResponseTest` cover both acknowledgement states per handler.

## Test plan

- `./mvnw test` on JDK 25: 48 tests, 0 failures (4 new).