### PR TITLE
feat: dispatch interaction handlers off the JDA event thread

### DIFF
--- a/src/main/java/net/aerh/slashcommands/SlashCommandManager.java
+++ b/src/main/java/net/aerh/slashcommands/SlashCommandManager.java
@@ -22,6 +22,10 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Main manager class for Discord slash commands using JDA.
  * Uses object-oriented design principles with separated concerns and dependency injection.
@@ -45,6 +49,13 @@ import org.slf4j.LoggerFactory;
  *     .scanPackage("com.example.commands")
  *     .build();
  * }</pre>
+ *
+ * <p>Command, button, string-select and modal handlers are dispatched on a worker thread pool
+ * rather than the JDA event thread, so a handler that blocks (for example on
+ * {@code RestAction.complete()}) cannot stall gateway event processing. Autocomplete is answered
+ * inline on the event thread because it is time-sensitive and expected to be non-blocking. Supply a
+ * custom pool via {@link SlashCommandManagerBuilder#withCommandExecutor(ExecutorService)}; the
+ * default is a daemon-threaded cached pool that is shut down when JDA shuts down.
  */
 public class SlashCommandManager extends ListenerAdapter {
     private static final Logger logger = LoggerFactory.getLogger(SlashCommandManager.class);
@@ -56,16 +67,28 @@ public class SlashCommandManager extends ListenerAdapter {
     private final AutocompleteHandler autocompleteHandler;
     private final ComponentInteractionHandler componentHandler;
     private final ModalInteractionHandler modalHandler;
+    private final ExecutorService dispatchExecutor;
 
     private JDA jda;
 
     /**
-     * Constructs a new SlashCommandManager with the provided PermissionManager.
-     * If no PermissionManager is provided, a default instance will be created.
+     * Constructs a new SlashCommandManager with the provided PermissionManager and the default
+     * dispatch executor.
      *
      * @param permissionManager the PermissionManager to use, or null to create a default one
      */
     SlashCommandManager(PermissionManager permissionManager) {
+        this(permissionManager, null);
+    }
+
+    /**
+     * Constructs a new SlashCommandManager.
+     *
+     * @param permissionManager the PermissionManager to use, or null to create a default one
+     * @param dispatchExecutor  the executor that runs command/component/modal handlers off the event
+     *                          thread, or null to use a default daemon-threaded cached pool
+     */
+    SlashCommandManager(PermissionManager permissionManager, ExecutorService dispatchExecutor) {
         this.registry = new SlashCommandRegistry();
         this.permissionManager = permissionManager != null ? permissionManager : new PermissionManager();
 
@@ -75,6 +98,32 @@ public class SlashCommandManager extends ListenerAdapter {
         this.autocompleteHandler = new AutocompleteHandler(registry);
         this.componentHandler = new ComponentInteractionHandler(registry);
         this.modalHandler = new ModalInteractionHandler(registry);
+        this.dispatchExecutor = dispatchExecutor != null ? dispatchExecutor : defaultDispatchExecutor();
+    }
+
+    private static ExecutorService defaultDispatchExecutor() {
+        AtomicInteger threadCount = new AtomicInteger();
+        return Executors.newCachedThreadPool(task -> {
+            Thread thread = new Thread(task, "slashcommands-dispatch-" + threadCount.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    /**
+     * Runs an interaction handler on the dispatch executor so a blocking handler cannot stall the
+     * JDA event thread. Any uncaught error is logged rather than silently swallowed by the executor.
+     *
+     * @param handlerInvocation the handler call to run off the event thread
+     */
+    private void dispatch(Runnable handlerInvocation) {
+        dispatchExecutor.execute(() -> {
+            try {
+                handlerInvocation.run();
+            } catch (Throwable throwable) {
+                logger.error("Uncaught error while dispatching an interaction", throwable);
+            }
+        });
     }
 
     /**
@@ -178,35 +227,38 @@ public class SlashCommandManager extends ListenerAdapter {
     @SubscribeEvent
     public void onShutdown(@NotNull ShutdownEvent event) {
         permissionManager.clearHandlers();
+        dispatchExecutor.shutdown();
     }
 
     @Override
     @SubscribeEvent
     public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
-        slashCommandHandler.handleSlashCommand(event);
+        dispatch(() -> slashCommandHandler.handleSlashCommand(event));
     }
 
     @Override
     @SubscribeEvent
     public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
+        // Answered inline on the event thread: autocomplete is time-sensitive (Discord's ~3s deadline)
+        // and expected to be non-blocking, so it should not queue behind dispatched command handlers.
         autocompleteHandler.handleAutocomplete(event);
     }
 
     @Override
     @SubscribeEvent
     public void onButtonInteraction(@NotNull ButtonInteractionEvent event) {
-        componentHandler.handleButtonInteraction(event);
+        dispatch(() -> componentHandler.handleButtonInteraction(event));
     }
 
     @Override
     @SubscribeEvent
     public void onStringSelectInteraction(@NotNull StringSelectInteractionEvent event) {
-        componentHandler.handleStringSelectInteraction(event);
+        dispatch(() -> componentHandler.handleStringSelectInteraction(event));
     }
 
     @Override
     @SubscribeEvent
     public void onModalInteraction(@NotNull ModalInteractionEvent event) {
-        modalHandler.handleModalInteraction(event);
+        dispatch(() -> modalHandler.handleModalInteraction(event));
     }
 }

--- a/src/main/java/net/aerh/slashcommands/SlashCommandManagerBuilder.java
+++ b/src/main/java/net/aerh/slashcommands/SlashCommandManagerBuilder.java
@@ -9,6 +9,7 @@ import net.hypixel.nerdbot.marmalade.pattern.Builder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Builder for creating and configuring SlashCommandManager instances.
@@ -33,6 +34,7 @@ public class SlashCommandManagerBuilder extends Builder<SlashCommandManager> {
     private JDA jda;
     private JDABuilder jdaBuilder;
     private PermissionManager permissionManager;
+    private ExecutorService commandExecutor;
 
     private SlashCommandManagerBuilder() {
         this.permissionManager = new PermissionManager();
@@ -87,6 +89,19 @@ public class SlashCommandManagerBuilder extends Builder<SlashCommandManager> {
      */
     public SlashCommandManagerBuilder withPermissionManager(PermissionManager permissionManager) {
         this.permissionManager = permissionManager;
+        return this;
+    }
+
+    /**
+     * Sets the executor used to run command, button, string-select and modal handlers off the JDA
+     * event thread. If not set, a default daemon-threaded cached pool is used and shut down when JDA
+     * shuts down; a supplied executor is left for the caller to manage.
+     *
+     * @param commandExecutor the executor to dispatch handlers on
+     * @return this builder for method chaining
+     */
+    public SlashCommandManagerBuilder withCommandExecutor(ExecutorService commandExecutor) {
+        this.commandExecutor = commandExecutor;
         return this;
     }
 
@@ -179,7 +194,7 @@ public class SlashCommandManagerBuilder extends Builder<SlashCommandManager> {
      */
     @Override
     protected SlashCommandManager construct() {
-        SlashCommandManager manager = new SlashCommandManager(permissionManager);
+        SlashCommandManager manager = new SlashCommandManager(permissionManager, commandExecutor);
 
         // Register configured commands and packages
         if (!commandInstances.isEmpty()) {

--- a/src/test/java/net/aerh/slashcommands/InteractionDispatchTest.java
+++ b/src/test/java/net/aerh/slashcommands/InteractionDispatchTest.java
@@ -1,0 +1,75 @@
+package net.aerh.slashcommands;
+
+import net.aerh.slashcommands.internal.core.PermissionManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How the manager routes interactions: command, button, string-select and modal handlers are
+ * dispatched off the event thread, while autocomplete is answered inline. The recording executor
+ * captures dispatched tasks without running them, so the {@code null} events are never touched.
+ */
+class InteractionDispatchTest {
+
+    private SlashCommandManager managerWith(RecordingExecutorService executor) {
+        return new SlashCommandManager(new PermissionManager(), executor);
+    }
+
+    @Test
+    @DisplayName("Slash commands are dispatched off the event thread")
+    void slashCommandsAreDispatched() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        managerWith(executor).onSlashCommandInteraction(null);
+        assertEquals(1, executor.taskCount());
+    }
+
+    @Test
+    @DisplayName("Button interactions are dispatched off the event thread")
+    void buttonInteractionsAreDispatched() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        managerWith(executor).onButtonInteraction(null);
+        assertEquals(1, executor.taskCount());
+    }
+
+    @Test
+    @DisplayName("String-select interactions are dispatched off the event thread")
+    void stringSelectInteractionsAreDispatched() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        managerWith(executor).onStringSelectInteraction(null);
+        assertEquals(1, executor.taskCount());
+    }
+
+    @Test
+    @DisplayName("Modal interactions are dispatched off the event thread")
+    void modalInteractionsAreDispatched() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        managerWith(executor).onModalInteraction(null);
+        assertEquals(1, executor.taskCount());
+    }
+
+    @Test
+    @DisplayName("Autocomplete is answered inline, not dispatched")
+    void autocompleteIsAnsweredInline() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        SlashCommandManager manager = managerWith(executor);
+
+        try {
+            manager.onCommandAutoCompleteInteraction(null);
+        } catch (Throwable ignored) {
+            // Handling a null event inline may throw; the point is that nothing was dispatched.
+        }
+
+        assertEquals(0, executor.taskCount());
+    }
+
+    @Test
+    @DisplayName("Shutting down JDA shuts down the dispatch executor")
+    void shutdownStopsExecutor() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+        managerWith(executor).onShutdown(null);
+        assertTrue(executor.isShutdown());
+    }
+}

--- a/src/test/java/net/aerh/slashcommands/RecordingExecutorService.java
+++ b/src/test/java/net/aerh/slashcommands/RecordingExecutorService.java
@@ -1,0 +1,57 @@
+package net.aerh.slashcommands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test executor that records submitted tasks instead of running them, so a test can assert whether
+ * an interaction was dispatched off the event thread without depending on real threading.
+ */
+class RecordingExecutorService extends AbstractExecutorService {
+
+    private final List<Runnable> tasks = new ArrayList<>();
+    private boolean shutdown = false;
+
+    @Override
+    public void execute(Runnable command) {
+        tasks.add(command);
+    }
+
+    int taskCount() {
+        return tasks.size();
+    }
+
+    void runAll() {
+        for (Runnable task : tasks) {
+            task.run();
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        shutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown = true;
+        return new ArrayList<>(tasks);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return shutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+}


### PR DESCRIPTION
Command, button, string-select and modal handlers were invoked synchronously from `SlashCommandManager`'s `@SubscribeEvent` listener methods, i.e. on JDA's event-dispatch thread. A handler that blocks, most commonly `event.deferReply().complete()` or any other `RestAction.complete()`, therefore stalled gateway event processing for the length of each REST round-trip, serialising all interactions under load.

This dispatches those four handler types onto an executor so the event thread is never blocked by handler code. Autocomplete is deliberately left inline: it is time-sensitive (Discord's ~3s deadline) and expected to be non-blocking, so it should not queue behind dispatched command handlers, and with commands offloaded the event thread is free to answer it promptly.

The default executor is a daemon-threaded cached pool (named `slashcommands-dispatch-N`), shut down on `ShutdownEvent`. A consumer can supply its own via `SlashCommandManagerBuilder.withCommandExecutor(ExecutorService)` to control sizing or share a pool. Uncaught errors on the worker thread are logged rather than being silently swallowed by the executor.

`InteractionDispatchTest` verifies each of the four types is dispatched and that autocomplete is not, plus executor shutdown on JDA shutdown, using a recording executor. Full suite passes (54).